### PR TITLE
fixes to run ARCH=amd64 qemu-run target in container-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ qemu-run: $(RPI3_IMG) $(TMP_USB_IMG)
 else ifeq ($(ARCH), amd64)
 qemu-run: $(PC_IMG) $(TMP_USB_IMG)
 	@echo -e "\nctrl-a x to exit qemu\n"
-	qemu-system-x86_64 -accel kvm:tcg -nographic -m 1024 \
+	qemu-system-x86_64 -machine pc,accel=kvm:tcg -nographic -m 1024 \
 	  -hda $(PC_IMG) -hdb $(TMP_USB_IMG)
 endif
 PHONY += qemu-run

--- a/container-build/packages
+++ b/container-build/packages
@@ -1,14 +1,16 @@
-build-essential
 bc
+build-essential
 cpio
 docker-ce-cli
 fakeroot
-gcc-aarch64-linux-gnu
 g++-aarch64-linux-gnu
+gcc-aarch64-linux-gnu
 gnupg2
+grub-common
 kmod
 libelf-dev
 mtools
+qemu-system-x86
 qemu-user-static
 rsync
 squashfs-tools
@@ -16,5 +18,6 @@ syslinux-common
 syslinux-efi
 u-boot-tools
 wget
+xorriso
 xz-utils
 zip


### PR DESCRIPTION
this adds the following new dependencies to the container, which is 18MB more to download and 68MB image disk space:

dmsetup gettext-base grub-common ipxe-qemu libaio1 libasound2 libasound2-data libasyncns0 libbluetooth3 libbrlapi0.6
libbsd0 libcaca0 libcacard0 libcap2 libdevmapper1.02.1 libfdt1 libflac8 libfreetype6 libfuse2 libice6 libjpeg62-turbo
libnspr4 libnss3 libnuma1 libogg0 libopus0 libpixman-1-0 libpng16-16 libpulse0 libsdl1.2debian libseccomp2 libslang2
libsm6 libsndfile1 libspice-server1 libusb-1.0-0 libusbredirparser1 libvdeplug2 libvorbis0a libvorbisenc2 libwrap0
libx11-6 libx11-data libx11-xcb1 libxau6 libxcb1 libxdmcp6 libxen-4.8 libxenstore3.0 libxext6 libxi6 libxtst6 libyajl2
qemu-system-common qemu-system-x86 seabios x11-common xorriso

for that reason, i'm not sure whether we should add qemu-system-x86_64 by default, or have a separate section in
container-build/build.cfg for optionally including these components. what do you think?