### PR TITLE
use buster-slim in container-build

### DIFF
--- a/container-build/build.cfg
+++ b/container-build/build.cfg
@@ -1,4 +1,5 @@
 # script/container-build configuration scripts
 
 [boundery-os-docker-builder]
+base-image=debian:buster-slim
 docker-passthrough


### PR DESCRIPTION
I had thought incorrectly we were using stretch for builds. Also, now we set the base-image explicitly in `container-build/build.cfg` instead of relying on the upstream container-build default (which I just changed to buster-slim but we haven't picked up that change yet).

Tested an arm64 build on my rpi4.