### PR TITLE
fix provisioning on non-FAT secondary storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ KERNEL_DTB := $(IMGFSDIR)/bcm2837-rpi-3-b-linux.dtb \
 KERNEL_DTB_DIR := $(KERNELDIR)/arch/$(KERNEL_ARCH)/boot/dts/broadcom
 endif
 kernel_dtb: $(KERNEL_DTB)
-$(KERNEL_DTB): $(IMGFSDIR)/%-linux.dtb: $(KERNEL_DTB_DIR)/%.dtb $(KERNEL)
+$(KERNEL_DTB:$(IMGFSDIR)%-linux.dtb=$(KERNEL_DTB_DIR)%.dtb): $(KERNEL)
+$(KERNEL_DTB): $(IMGFSDIR)/%-linux.dtb: $(KERNEL_DTB_DIR)/%.dtb
 	cp $< $@
 endif
 

--- a/containers/storagemgr/storagemgr
+++ b/containers/storagemgr/storagemgr
@@ -3,6 +3,7 @@
 import argparse
 import os
 import errno
+import mmap
 import re
 import subprocess
 import syslog
@@ -310,7 +311,8 @@ def makebuffer(filesize, blocksize):
         log.error("file size %s must be between 1 and 4000MiB" % (filesize))
         return None, None, None
     nblocks = int((filesize + (blocksize - 1)) / blocksize)
-    buf = [bytes(256 * 1024)] * (4 * blocksize)
+    # mmap for page-alignment since O_DIRECT needs buf alignment on some fs
+    buf = [mmap.mmap(-1, 256 * 1024)] * (4 * blocksize)
     bufsize = 1048576 * blocksize
     nbytes = bufsize * nblocks
     return buf, bufsize, nbytes


### PR DESCRIPTION
O_DIRECT requires buffer alignment on some fs (including ext4 on the kernel version we're on), so we use mmap to conservatively align our buf to page boundaries.

tested on my rpi4