### PR TITLE
add dropbear for debugging, disabled by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,10 +541,26 @@ registration_clean:
 	$(SCRIPTDIR)/mkcontainer -c registration '$(FROM_PREFIX)' \
 	  $(FSDIR) $(IMGFSDIR)/layers
 
+SSHD := $(IMGFSDIR)/layers/sshd.off
+sshd: $(SSHD)
+$(SSHD): $(CONTAINERDIR)/sshd/* $(SCRIPTDIR)/untar-docker-image
+	$(SCRIPTDIR)/mkcontainer -t sshd '$(FROM_PREFIX)' \
+		$(CONTAINERDIR)/sshd \
+		$(FSDIR) \
+		$(IMGFSDIR)/layers \
+		'$(DOCKER_BUILD_PROXY)'
+CONTAINERS += $(SSHD)
+
+PHONY += sshd_clean
+sshd_clean:
+	$(SCRIPTDIR)/mkcontainer -c sshd '$(FROM_PREFIX)' \
+		$(FSDIR) \
+		$(IMGFSDIR)/layers
+
 PHONY += fs_clean
 fs_clean: rootfs_clean python3_clean storagemgr_clean zerotier_clean \
           haproxy_clean dnsd_clean certmgr_clean web_clean appstore_clean \
-	  registration_clean
+	  registration_clean sshd_clean
 	rm -rf $(FSDIR) $(FSDIR).fakeroot
 
 SQUASHFS := $(IMGFSDIR)/layers/fs.sqfs

--- a/Makefile
+++ b/Makefile
@@ -544,7 +544,7 @@ registration_clean:
 SSHD := $(IMGFSDIR)/layers/sshd.off
 sshd: $(SSHD)
 $(SSHD): $(CONTAINERDIR)/sshd/* $(SCRIPTDIR)/untar-docker-image
-	$(SCRIPTDIR)/mkcontainer -t sshd '$(FROM_PREFIX)' \
+	$(SCRIPTDIR)/mkcontainer -St sshd '$(FROM_PREFIX)' \
 		$(CONTAINERDIR)/sshd \
 		$(FSDIR) \
 		$(IMGFSDIR)/layers \

--- a/containers/sshd/Dockerfile
+++ b/containers/sshd/Dockerfile
@@ -1,0 +1,20 @@
+ARG FROM_PREFIX
+
+FROM ${FROM_PREFIX}debian:stretch-slim
+
+RUN    apt-get update \
+    && apt-get install -y --no-install-recommends \
+           dropbear-bin \
+    && rm -rf \
+           /var/lib/apt/lists/* \
+           /var/lib/dpkg/status-old \
+           /var/log/apt \
+           /var/log/dpkg.log
+
+RUN    mkdir -p /etc/dropbear /root/.ssh \
+    && chmod 700 /root/.ssh \
+    && ln -s /boot/ssh_host_rsa_key /etc/dropbear/dropbear_rsa_host_key \
+    && ln -s /boot/ssh_host_ecdsa_key /etc/dropbear/dropbear_ecdsa_host_key \
+    && ln -s /boot/ssh_authorized_keys /root/.ssh/authorized_keys
+
+COPY startsshd /usr/local/sbin/

--- a/containers/sshd/startsshd
+++ b/containers/sshd/startsshd
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+#
+# Constants
+#
+
+SSH_AUTHORIZED_KEYS_PATH=/boot/ssh_authorized_keys
+SSH_HOST_KEY_PATH=/boot/ssh_host_rsa_key
+
+#
+# Global variables
+#
+
+progname="${0##*/}"
+
+#
+# Main
+#
+
+main() {
+    parseargs "$@" || return 99
+
+    if ! [ -f "$SSH_AUTHORIZED_KEYS_PATH" ]; then
+        verbose "Authorized keys file $SSH_AUTHORIZED_KEYS_PATH not found; exiting"
+        exit 0
+    fi
+
+    if ! [ -f "$SSH_HOST_KEY_PATH" ]; then
+        info "Generating host key $SSH_HOST_KEY_PATH"
+        if ! dropbearkey -t rsa -s 2048 -f "$SSH_HOST_KEY_PATH"; then
+            error "Error generating host key $SSH_HOST_KEY_PATH"
+            exit 1
+        fi
+        sync -f "$SSH_HOST_KEY_PATH"
+    fi
+
+    dropbear_flags=
+    [ "$dflag" ] && dropbear_flags="${dropbear_flags} -FE"
+
+    info "Starting sshd"
+    dropbear -sm $dropbear_flags
+}
+
+parseargs() {
+    while getopts dqv opt; do
+        case $opt in
+        (d)
+            dflag=1
+            ;;
+        (q)
+            qflag=1
+            ;;
+        (v)
+            vflag=1
+            ;;
+        (\?)
+            usage
+            return 1
+            ;;
+        esac
+    done
+    shift $(($OPTIND - 1))
+    # just ignore the rest of argv
+
+    return 0
+}
+
+usage() {
+    {
+    echo "Usage: $progname [-dkn]"
+    echo "Start SSH server if $SSH_AUTHORIZED_KEYS_PATH is present."
+    echo "Generate RSA host key at $SSH_HOST_KEY_PATH if necessary."
+    echo
+    echo "    -d   debug, run in foreground, log to stdout, log more"
+    echo "    -q   quiet, log less"
+    echo "    -v   verbose, log more"
+    } >&2
+}
+
+#
+# Logging and debugging
+#
+
+log() {
+    local prio="$1"
+    shift
+
+    if [ "$dflag" ]; then
+        echo "$*"
+        return
+    fi
+    logger -pdaemon."$prio" -t"$progname" "$*"
+}
+
+error() {
+    log err "$@"
+}
+
+warning() {
+    log warning "$@"
+}
+
+info() {
+    [ "$qflag" ] || log info "$@"
+}
+
+debug() {
+    [ "$dflag" ] && log debug "$@"
+}
+
+verbose() {
+    [ "$vflag" ] && log info "$@"
+}
+
+
+#
+# Run
+#
+
+main "$@"
+exit $?

--- a/initrdsrc/init
+++ b/initrdsrc/init
@@ -43,6 +43,9 @@ add_layers() {
 }
 
 add_layers rootfs
+if [ -f /boot/ssh_authorized_keys ]; then
+    add_layers sshd
+fi
 # XXX debugging: add more layers
 #add_layers python3
 #add_layers storagemgr

--- a/rootsrc/init
+++ b/rootsrc/init
@@ -32,6 +32,11 @@ done </etc/modules
 
 (netd &)
 
+# try to start sshd if the sshd layer was mounted by initrd
+if which startsshd &>/dev/null; then
+    startsshd
+fi
+
 # Bring up mdev to run storage manager
 mkdir -p /tmp/lvm/etc
 cp /etc/lvm/lvm.conf /tmp/lvm/etc

--- a/rootsrc/init
+++ b/rootsrc/init
@@ -33,7 +33,7 @@ done </etc/modules
 (netd &)
 
 # try to start sshd if the sshd layer was mounted by initrd
-if which startsshd &>/dev/null; then
+if which startsshd >/dev/null 2>&1; then
     startsshd
 fi
 

--- a/script/mkcontainer
+++ b/script/mkcontainer
@@ -6,9 +6,10 @@ buildargs=
 cflag=
 rflag=
 tflag=
+Sflag=
 
 main() {
-    while getopts a:crt opt; do
+    while getopts a:crSt opt; do
         case $opt in
 	(a)
             buildargs="$buildargs --build-arg $OPTARG"
@@ -18,6 +19,9 @@ main() {
             ;;
         (r)
             rflag=1
+            ;;
+        (S)
+            Sflag=1
             ;;
         (t)
             tflag=1
@@ -47,6 +51,7 @@ usage() {
     echo "          -a   pass --build-arg name=value to docker build"
     echo "          -r   rename layer from hash to container name"
     echo "          -t   save tar fragments"
+    echo "          -S   deny shadowing files from the base layer"
     echo "  $progname -c name from-prefix fs-dir layers-dir"
     echo "      clean up container"
     } >&2
@@ -87,12 +92,31 @@ build () {
     mkdir -p $fsdir $layersdir
     docker save $from_prefix$name | $fakeroot $untar $fsdir
 
+    if [ "$Sflag" ]; then
+        baselayer=$(head -n 1 $layersdir/$name.layers)
+        for layer in $(tail -n +2 $layersdir/$name.layers); do
+            shadows=$(layer_shadows $baselayer $layer | sed -e '\,^var/lib/apt/,d' -e '\,^var/lib/dpkg/,d')
+            if [ -n "$shadows" ]; then
+                echo "$progname: Error: Layer $layer shadows files in base layer $baselayer:"
+                echo "$shadows"
+                rm -f $layersdir/$name.*
+                exit 1
+            fi
+        done
+    fi
+
     if [ "$rflag" ]; then
         layer=$(tail -1 $layersdir/$name.layers)
         echo "$progname: Renaming layer $layer to $name"
         mv $fsdir/$layer $fsdir/$name
         sed -i "\$s/.*/$name/" $layersdir/$name.layers
     fi
+}
+
+layer_shadows() {
+    find $fsdir/$1 $fsdir/$2 -type f -printf '%P\n' |
+        sort | uniq -c |
+        sed -n -e 's/^[[:space:]]*[2-9][0-9]* //p'
 }
 
 clean() {


### PR DESCRIPTION
a dropbear server will be started if /boot/ssh_authorized_keys is present. a host key will be generated to
/boot/ssh_host_rsa_key if not already present.

dropbear-bin doesn't pull in any extra dependencies and its installed size is only 685k.

    root@prjx:~# apt remove --dry-run --autoremove dropbear-bin
    ...
    0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.

    root@prjx:~# stat --format='%s' $(dpkg -L dropbear-bin) 2>/dev/null | perl -ne '$s += $_; END { print "$s\n" }'
    685396